### PR TITLE
Promote to prod environment

### DIFF
--- a/components/githubactions-go-ajiahgeq/overlays/prod/deployment-patch.yaml
+++ b/components/githubactions-go-ajiahgeq/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: nexus-docker-nexus.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/githubactions-go-ajiahgeq:github-4936f940a37017045b43367aabc0886f825cf5b0
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: nexus-docker-nexus.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/githubactions-go-ajiahgeq:github-4936f940a37017045b43367aabc0886f825cf5b0